### PR TITLE
Refer to tabix on debian distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The script will check for the following prerequisites.
 - docker 
 - pgrep 
 - gzip 
-- bgzip
+- bgzip (tabix on debian based linux distributions)
 
 ### Disk space
 At least 30GB of disk space are required.


### PR DESCRIPTION
On debian based linux distributions `bgzip` is not available though the `apt` package manager.
Instead it is part of the `tabix`-package (see https://manpages.debian.org/bullseye/tabix/index.html).
To prevent any confusion I would refer to it in the readme.