### PR TITLE
Handling of special characters and moving renamed vcfs

### DIFF
--- a/Run_VEP_batch.sh
+++ b/Run_VEP_batch.sh
@@ -117,6 +117,10 @@ for f in $(find input/ -name '*\ *.vcf' -mmin +$waitperiod)
     basename=${basename//)/}
     mv "$f" "input/$basename"
     printf "I don't like whitespaces: $f is renamed to $basename\n"
+    # Remove empty directories after files have been moved
+    if [ -f "input/$basename" ];then
+      rm -r "${f%/*}/"
+    fi
   done
 IFS=$SAVEIFS
 

--- a/Run_VEP_batch.sh
+++ b/Run_VEP_batch.sh
@@ -118,7 +118,7 @@ for f in $(find input/ -name '*\ *.vcf' -mmin +$waitperiod)
     mv "$f" "input/$basename"
     printf "I don't like whitespaces: $f is renamed to $basename\n"
     # Remove empty directories after files have been moved
-    if [ "${f%/*}/" != "input/" ];then
+    if [ ! "$(ls -A ${f%/*}/)" ] && [ "${f%/*}/" != "input/" ];then
       rmdir "${f%/*}/"
     fi
   done

--- a/Run_VEP_batch.sh
+++ b/Run_VEP_batch.sh
@@ -120,7 +120,7 @@ for f in $(find input/ -name '*\ *.vcf' -mmin +$waitperiod)
   done
 IFS=$SAVEIFS
 
-for i in $(find input/ -name '*.vcf')
+for i in $(find input/ -name '*.vcf' -mmin +$waitperiod)
   do
     #BASENAME=$( echo $i | cut -d'/' -f2)
     basename=${i##*/}

--- a/Run_VEP_batch.sh
+++ b/Run_VEP_batch.sh
@@ -118,8 +118,8 @@ for f in $(find input/ -name '*\ *.vcf' -mmin +$waitperiod)
     mv "$f" "input/$basename"
     printf "I don't like whitespaces: $f is renamed to $basename\n"
     # Remove empty directories after files have been moved
-    if [ -f "input/$basename" ];then
-      rm -r "${f%/*}/"
+    if [ "${f%/*}/" != "input/" ];then
+      rmdir "${f%/*}/"
     fi
   done
 IFS=$SAVEIFS

--- a/Run_VEP_batch.sh
+++ b/Run_VEP_batch.sh
@@ -128,7 +128,7 @@ for i in $(find input/ -name '*.vcf' -mmin +$waitperiod)
   do
     #BASENAME=$( echo $i | cut -d'/' -f2)
     basename=${i##*/}
-    basename_we=$( echo $basename | cut -d'.' -f1)
+    basename_we=$(basename $basename ".vcf")
     outname=${basename_we}_VEP_RefSeq.vcf
 
     cp $i archive

--- a/Run_VEP_batch.sh
+++ b/Run_VEP_batch.sh
@@ -105,18 +105,22 @@ if [ $(df -P . | tail -1 | xargs | cut -d" " -f4) -lt 5000000 ];then
   printf "INFO: There is less then 5GB space left on your disk, please check\n"
 fi
 
+#for every file that ends with .vcf that stayed there for longer than timeout (that value is stored in the config)
 #check for whitespaces and repaces them with underscore
 SAVEIFS=$IFS
 IFS=$'\n'
-for f in $(find input/ -name '*\ *.vcf')
-do
-  mv "$f" "${f// /_}"
-  printf "I don't like whitespaces: $f is renamed to ${f// /_}"
-done
+for f in $(find input/ -name '*\ *.vcf' -mmin +$waitperiod)
+  do
+    basename=${f##*/}
+    basename=${basename// /_}
+    basename=${basename//(/}
+    basename=${basename//)/}
+    mv "$f" "input/$basename"
+    printf "I don't like whitespaces: $f is renamed to $basename\n"
+  done
 IFS=$SAVEIFS
 
-#for every file that ends with .vfc that stayed ther for longer than timeout (that value is stored in the config)
-for i in $(find input/ -name '*.vcf' -mmin +$waitperiod)
+for i in $(find input/ -name '*.vcf')
   do
     #BASENAME=$( echo $i | cut -d'/' -f2)
     basename=${i##*/}


### PR DESCRIPTION
In the current implementation the whitespaces will be removed by moving the vcf-files containing white spaces.
As directories may also also contain whitespaces the path for the renamed file will also differ from the original file path.
This causes the 'mv' command to fail as the path does not exist e.g.:
`mv "input/path containing whitespaces/file with space.vcf input/path_containing_whitespaces/file_with_space.vcf`.

To fix this files will just be moved to the upper level of the input-directory for further processing

Additionally, it turned out that the script fails in case the file names contain braces (`(` and `)`) e.g. `Final Filtered Variants-W56-11-E-1234-43-3A-SD1-0V3_S18_L001 (paired).vcf`
I handled this by just removing them from filenames as they are not required as separator.

My fix lacks of a bit redundancy. So replacing characters by a dictionary which can be easily extended in case of other special characters would be a better way.